### PR TITLE
Matrix builds (Linux/macOS/Windows) added to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
       run: ctest --preset release --output-on-failure --verbose
     
     - name: Run Backtest (Integration Test - UNIX)
-      if: runner.os != 'Windows'
+      if: runner.os == 'Linux'
       run: timeout 60s ./build/release/src/backtest
 
     - name: Run Backtest (Integration Test - Windows)
-      if: runner.os == 'Windows'
+      if: runner.os != 'Linux'
       run: .\build\release\src\Release\backtest.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,16 @@ jobs:
     - name: Run Unit Tests
       run: ctest --preset release --output-on-failure --verbose
     
-    - name: Run Backtest (Integration Test - UNIX)
+    - name: Run Backtest (Integration Test - Linux)
       if: runner.os == 'Linux'
       run: timeout 60s ./build/release/src/backtest
 
+    - name: Run Backtest (Integration Test - macOS) 
+      if: runner.os == 'macOS'
+      timeout-minutes: 1
+      run: timeout 60s ./build/release/src/backtest
+
     - name: Run Backtest (Integration Test - Windows)
-      if: runner.os != 'Linux'
+      if: runner.os == 'Windows'
+      timeout-minutes: 1
       run: .\build\release\src\Release\backtest.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Run Backtest (Integration Test - macOS) 
       if: runner.os == 'macOS'
       timeout-minutes: 1
-      run: timeout 60s ./build/release/src/backtest
+      run: ./build/release/src/backtest
 
     - name: Run Backtest (Integration Test - Windows)
       if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,20 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
     
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
     
-    - name: Install dependencies
+    - name: Install dependencies (Linux)
+      if: runner.os == 'Linux'
       run: |
         sudo apt-get update
         sudo apt-get install -y \
@@ -24,6 +31,7 @@ jobs:
           g++-13
     
     - name: Set GCC 13 as default
+      if: runner.os == 'Linux'
       run: |
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
@@ -32,10 +40,15 @@ jobs:
       run: cmake --preset release
     
     - name: Build
-      run: cmake --build --preset release -j $(nproc)
+      run: cmake --build --preset release --parallel
     
     - name: Run Unit Tests
       run: ctest --preset release --output-on-failure --verbose
     
-    - name: Run Backtest (Integration Test)
+    - name: Run Backtest (Integration Test - UNIX)
+      if: runner.os != 'Windows'
       run: timeout 60s ./build/release/src/backtest
+
+    - name: Run Backtest (Integration Test - Windows)
+      if: runner.os == 'Windows'
+      run: .\build\release\src\Release\backtest.exe

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -37,22 +37,26 @@
   "buildPresets": [
     {
       "name": "dev",
-      "configurePreset": "dev"
+      "configurePreset": "dev",
+      "configuration": "Debug"
     },
     {
       "name": "release",
-      "configurePreset": "release"
+      "configurePreset": "release",
+      "configuration": "Release"
     }
   ],
   "testPresets": [
     {
       "name": "dev",
       "configurePreset": "dev",
+      "configuration": "Release",
       "output": { "outputOnFailure": true }
     },
     {
       "name": "release",
       "configurePreset": "release",
+      "configuration": "Release",
       "output": { "outputOnFailure": true }
     }
   ]

--- a/include/backtest-cpp/data.h
+++ b/include/backtest-cpp/data.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cstring>
+#include <string>
+#include <cstdint>
 #include <map>
 #include <string_view>
 #include <vector>

--- a/include/backtest-cpp/strategy.h
+++ b/include/backtest-cpp/strategy.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstring>
+#include <cstdint>
 #include <deque>
 #include <map>
 #include <optional>

--- a/include/backtest-cpp/utils.h
+++ b/include/backtest-cpp/utils.h
@@ -1,6 +1,7 @@
 #include <chrono>
 #include <string>
 #include <string_view>
+#include <cstdint> 
 
 // String utilities
 std::string extractSymbolFromPath(const std::string& filepath);

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -1,12 +1,12 @@
-#include "backtest-cpp/data.h"
-
 #include <filesystem>
 #include <fstream>
+#include <string>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <vector>
 
+#include "backtest-cpp/data.h"
 #include "backtest-cpp/utils.h"
 
 void DataHandler::loadCSV(const std::string& filepath, uint32_t symbol_id,

--- a/src/portfolio.cpp
+++ b/src/portfolio.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <iostream>
 #include <vector>
+#include <cstdlib> 
 
 #include "backtest-cpp/types.h"
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -7,6 +7,10 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <charconv>
+#include <system_error>
+#include <iomanip>
+#include <ctime>  
 
 std::string extractSymbolFromPath(const std::string& path) {
     return std::filesystem::path(path).stem().string();

--- a/tests/test_portfolio.cpp
+++ b/tests/test_portfolio.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdint>
 #include <ctime>
 


### PR DESCRIPTION
* Extended our CI to also build and run the backtester on windows and mac.
* Add standard includes for stricter Compilers

This will (hopefully) once and for all rid us of the 30 min sessions debugging OS compatibility  at the start of our AIC-Quant meetings ;)