### PR TITLE
ci(workflow): optimize build pipeline and upgrade checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
-
     strategy:
       fail-fast: false
       matrix:
@@ -18,25 +20,12 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Install dependencies (Linux)
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          build-essential \
-          cmake \
-          gcc-13 \
-          g++-13
-    
-    - name: Set GCC 13 as default
-      if: runner.os == 'Linux'
-      run: |
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
+      uses: actions/checkout@v6
     
     - name: Configure CMake
+      env:
+        CC: ${{ matrix.os == 'ubuntu-latest' && 'gcc-13' || '' }}
+        CXX: ${{ matrix.os == 'ubuntu-latest' && 'g++-13' || '' }}
       run: cmake --preset release
     
     - name: Build
@@ -45,12 +34,8 @@ jobs:
     - name: Run Unit Tests
       run: ctest --preset release --output-on-failure --verbose
     
-    - name: Run Backtest (Integration Test - Linux)
-      if: runner.os == 'Linux'
-      run: timeout 60s ./build/release/src/backtest
-
-    - name: Run Backtest (Integration Test - macOS) 
-      if: runner.os == 'macOS'
+    - name: Run Backtest (Integration Test - Unix)
+      if: runner.os == 'Linux' || runner.os == 'macOS'
       timeout-minutes: 1
       run: ./build/release/src/backtest
 


### PR DESCRIPTION
I have refactored the CI workflow. Specifically, I implemented a security best practice, [PoLP](https://en.wikipedia.org/wiki/Principle_of_least_privilege), slightly reduced execution time by getting rid of redundant package installations, bumped actions/checkout from v4 to v6, and prevented side effects at the runner level through environment variables.