### PR TITLE
Refactor portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The goal of this project is to build this rather standard backtester into a low-
 (!) = High-Impact Optimization
 
 ### Phase 1: Quick Wins (Cache & Parsing)
-- [IN PROGRESS] Refactor commission logic
+- [X] Refactor commission logic
 - [X] (!) **Symbol Interning:** Replace `std::string` instrument keys with `uint32_t` IDs or Enums to remove string comparisons and allocations.
 - [X] (!) **Contiguous Data Structures:** Replace `std::map<std::string, Bar>` with `std::vector<Bar>` indexed by Instrument ID to eliminate cache misses from pointer chasing.
 - [X] **High-Precision Time:** Replace `time_t` (seconds) with `std::chrono::nanoseconds` or `int64_t` (nanoseconds since epoch).

--- a/include/backtest-cpp/portfolio.h
+++ b/include/backtest-cpp/portfolio.h
@@ -27,7 +27,7 @@ class Portfolio {
     std::vector<Trade> getAllTrades() const;
     double getAvailableCash() const;
     void closeAllPositions(const std::vector<Bar>& currentBars);
-    void executeOrder(const Order& order, const bool close);
+    void executeOrder(const Order& order, const bool close = false);
 
    private:
     double availableCash_ = 10000;

--- a/include/backtest-cpp/types.h
+++ b/include/backtest-cpp/types.h
@@ -50,5 +50,4 @@ struct Position {
     uint32_t symbol_id;
     int quantity;
     double averagePrice;
-    SignalType direction;
 };

--- a/src/portfolio.cpp
+++ b/src/portfolio.cpp
@@ -25,7 +25,8 @@ double Portfolio::getInvestedValue(const std::vector<Bar>& currentBars) const {
             std::cerr << "ERROR: Missing price for position " << symbol_id << std::endl;
             throw std::runtime_error("Cannot calculate equity without price"); // TODO create a last available price vector
         }
-        totalPositionValue += currentBars.at(symbol_id).close * abs(position.quantity);
+        totalPositionValue += abs(position.quantity) * position.averagePrice
+                            + position.quantity * (currentBars.at(symbol_id).close - position.averagePrice);
     }
     return totalPositionValue;
 }
@@ -157,8 +158,8 @@ void Portfolio::executeOrder(const Order& order, const bool close) {
                                     .quantity = closedQuantity,
                                     .pnl = tradePnl,
                                     .commission = commission_});
+            availableCash_ += (abs(closedQuantity) * pos.averagePrice + tradePnl - commission_);
             // average price doesn't change
-            availableCash_ -= (-abs(order.quantity) * order.price + commission_);
             pos.quantity += order.quantity;
         }
         else if(abs(order.quantity) > abs(pos.quantity)) { // FLIP
@@ -168,9 +169,10 @@ void Portfolio::executeOrder(const Order& order, const bool close) {
                                     .quantity = closedQuantity,
                                     .pnl = tradePnl,
                                     .commission = commission_});
+            availableCash_ += (abs(closedQuantity) * pos.averagePrice + tradePnl - commission_);
+            availableCash_ -= (abs(pos.quantity + order.quantity) * order.price);
             pos.averagePrice = order.price;
-            availableCash_ -= (-abs(pos.quantity) * order.price + commission_);
-            availableCash_ -= (abs(pos.quantity - order.quantity) * order.price);
+            
             pos.quantity += order.quantity;
             
         }  
@@ -181,7 +183,7 @@ void Portfolio::executeOrder(const Order& order, const bool close) {
                                     .quantity = closedQuantity,
                                     .pnl = tradePnl,
                                     .commission = commission_});
-            availableCash_ -= (-abs(order.quantity) * order.price + commission_);
+            availableCash_ += (abs(closedQuantity) * pos.averagePrice + tradePnl - commission_);
             positions_.erase(order.symbol_id);
         }
     }

--- a/src/portfolio.cpp
+++ b/src/portfolio.cpp
@@ -20,14 +20,14 @@ double Portfolio::getInvestedValue(const std::vector<Bar>& currentBars) const {
     double totalPositionValue = 0;
     for (const auto& [symbol_id, position] : positions_) {
         // std::cout << "CurrentBars.size() " << currentBars.size() << std::endl;
-        if (currentBars[symbol_id].symbol_id == 0) {  // ids start from 1, so 0 means doesn't exist
+        if (currentBars.at(symbol_id).symbol_id == 0) {  // ids start from 1, so 0 means doesn't exist
             // Use last known price or throw error - don't just skip!
             std::cerr << "ERROR: Missing price for position " << symbol_id << std::endl;
-            // throw std::runtime_error("Cannot calculate equity without price");
+            throw std::runtime_error("Cannot calculate equity without price"); // TODO create a last available price vector
         }
-        totalPositionValue += position.quantity * currentBars[symbol_id].close;
+        totalPositionValue += currentBars.at(symbol_id).close * abs(position.quantity);
     }
-    return fabs(totalPositionValue);
+    return totalPositionValue;
 }
 
 double Portfolio::getTotalEquity(const std::vector<Bar>& currentBars) const {
@@ -51,17 +51,17 @@ void Portfolio::closeAllPositions(const std::vector<Bar>& currentBars) {
         const Position& position = it->second;
 
         // Check if bar exists
-        if (currentBars[symbol_id].symbol_id == 0) {
+        if (currentBars.at(symbol_id).symbol_id == 0) {
             std::cerr << "WARNING: No price data for symbol " << symbol_id << std::endl;
-            //++it;
-            // continue;
+            ++it;
+            continue; // TODO create a last available price vector
         }
 
         // Build order using const references (no copies)
-        Order closeOrder{.time = currentBars[symbol_id].time,
+        Order closeOrder{.time = currentBars.at(symbol_id).time,
                          .symbol_id = symbol_id,
                          .direction = (position.quantity > 0) ? SignalType::SELL : SignalType::BUY,
-                         .price = currentBars[symbol_id].close,
+                         .price = currentBars.at(symbol_id).close,
                          .type = OrderType::MARKET,
                          .quantity = -position.quantity};
 
@@ -79,19 +79,22 @@ bool Portfolio::checkOverdraft(const Order& order) const {
     if (hasPosition) {
         const Position& pos = positions_.at(order.symbol_id);
         int netPositionSize = pos.quantity + order.quantity;
-
+        // if(pos.quantity * order.quantity < 0 && abs(pos.quantity) < abs(order.quantity)) { // checks if new order flips the position
+        //     return (abs(netPositionSize) * order.price + commission_ >
+        //         (availableCash_ * leverage_ + order.price * abs(pos.quantity) - commission_)); // account for double commision
+        // }
         return (abs(netPositionSize) * order.price + commission_ >
-                (availableCash_ * leverage_ + pos.averagePrice * abs(pos.quantity) - commission_));
+                (availableCash_ * leverage_ + order.price * abs(pos.quantity))); // TODO create a last available price vector and use it instead order.price
     } else {
         return (abs(order.quantity) * order.price + commission_) >
-               (availableCash_ * leverage_);  // NEEDS fixing for adjusting pos size
+               (availableCash_ * leverage_);
     }
 }
 
 double Portfolio::getRealizedPnL() const {
     double totalPnl = 0;
     for (const auto& trade : trades_) {
-        totalPnl += trade.pnl;
+        totalPnl += trade.pnl - trade.commission;
     }
     return totalPnl;
 }
@@ -106,7 +109,7 @@ double Portfolio::getUnrealizedPnL(const std::vector<Bar>& currentBars) const {
     return UnrealizedPnl;
 }
 
-void Portfolio::executeOrder(const Order& order, const bool close = false) {
+void Portfolio::executeOrder(const Order& order, const bool close) {
     auto posIt = positions_.find(order.symbol_id);
     bool hasPosition = (posIt != positions_.end());
 
@@ -120,61 +123,66 @@ void Portfolio::executeOrder(const Order& order, const bool close = false) {
         return;
     }
 
-    // NEW POSITION
-    if (!hasPosition) {
+    if (!hasPosition) { // OPEN
         positions_[order.symbol_id] = Position{
             .symbol_id = order.symbol_id,
             .quantity = order.quantity,
-            .averagePrice = order.price,
-            .direction = (order.quantity > 0) ? SignalType::BUY : SignalType::SELL,
+            .averagePrice = order.price
         };
-
-        double totalCost = fabs(order.quantity) * order.price + commission_;
+        trades_.push_back(Trade{.order = order,
+                                    .quantity = 0,
+                                    .pnl = 0,
+                                    .commission = commission_}); // add a trade to account for the commision while calculating Pnl
+        double totalCost = abs(order.quantity) * order.price + commission_;
         availableCash_ -= totalCost;
-
         // Adjust position
-    } else {
+    } 
+    else {
         Position& pos = positions_[order.symbol_id];
 
-        // Add to position
-        if ((order.direction == SignalType::BUY && pos.direction == SignalType::BUY) ||
-            (order.direction == SignalType::SELL && pos.direction == SignalType::SELL)) {
+        if((order.quantity > 0) ==  (pos.quantity > 0)) { // ADD
             pos.averagePrice = (pos.quantity * pos.averagePrice + order.quantity * order.price) /
                                static_cast<double>(pos.quantity + order.quantity);
-            availableCash_ -= (order.quantity * order.price + commission_);
-
-            // Remove from position
-        } else {
-            int netPositionSize = pos.quantity + order.quantity;
-
-            int closedQuantity =
-                abs(order.quantity) >= abs(pos.quantity) ? pos.quantity : order.quantity;
-            double tradePnl = closedQuantity * (order.price - pos.averagePrice) - commission_;
+            availableCash_ -= (abs(order.quantity) * order.price + commission_);
+            pos.quantity += order.quantity;
+            trades_.push_back(Trade{.order = order,
+                                    .quantity = 0,
+                                    .pnl = 0,
+                                    .commission = commission_}); // add a trade to account for the commision while calculating Pnl
+        }
+        else if(abs(order.quantity) < abs(pos.quantity)) { // REDUCE
+            int closedQuantity = -order.quantity;
+            double tradePnl = closedQuantity * (order.price - pos.averagePrice);
             trades_.push_back(Trade{.order = order,
                                     .quantity = closedQuantity,
                                     .pnl = tradePnl,
                                     .commission = commission_});
-            // DEBUG
-            // std::cout << "Logged Trade | " << "Closed: " << closedQuantity << " Entered @ "
-            //           << pos.averagePrice << " Exited @ " << order.price << " P&L: " << tradePnl
-            //           << std::endl;
-
-            availableCash_ += (abs(closedQuantity) * pos.averagePrice + tradePnl + commission_);
-
-            if (abs(order.quantity) > abs(pos.quantity)) {
-                availableCash_ -= (abs(pos.quantity + order.quantity) * order.price + commission_);
-            }
-
-            pos.quantity = netPositionSize;
-            pos.averagePrice =
-                abs(pos.quantity) > abs(order.quantity) ? pos.averagePrice : order.price;
-            pos.direction =
-                abs(pos.quantity) > abs(order.quantity) ? pos.direction : order.direction;
-
-            // Remove Empty Position
-            if (netPositionSize == 0) {
-                positions_.erase(order.symbol_id);
-            }
+            // average price doesn't change
+            availableCash_ -= (-abs(order.quantity) * order.price + commission_);
+            pos.quantity += order.quantity;
+        }
+        else if(abs(order.quantity) > abs(pos.quantity)) { // FLIP
+            int closedQuantity = pos.quantity;
+            double tradePnl = closedQuantity * (order.price - pos.averagePrice);
+            trades_.push_back(Trade{.order = order,
+                                    .quantity = closedQuantity,
+                                    .pnl = tradePnl,
+                                    .commission = commission_});
+            pos.averagePrice = order.price;
+            availableCash_ -= (-abs(pos.quantity) * order.price + commission_);
+            availableCash_ -= (abs(pos.quantity - order.quantity) * order.price);
+            pos.quantity += order.quantity;
+            
+        }  
+        else { // CLOSE
+            int closedQuantity = pos.quantity;
+            double tradePnl = closedQuantity * (order.price - pos.averagePrice);
+            trades_.push_back(Trade{.order = order,
+                                    .quantity = closedQuantity,
+                                    .pnl = tradePnl,
+                                    .commission = commission_});
+            availableCash_ -= (-abs(order.quantity) * order.price + commission_);
+            positions_.erase(order.symbol_id);
         }
     }
 

--- a/tests/test_portfolio.cpp
+++ b/tests/test_portfolio.cpp
@@ -260,7 +260,7 @@ TEST_F(PortfolioTest, OpenShortPositionCorrectInvestedValue) {
     std::vector<Bar> bars(NQ_ID + 1);
     bars[NQ_ID] = createTestBar(NQ_ID, 95.0);
 
-    EXPECT_DOUBLE_EQ(portfolio->getInvestedValue(bars), 950.0);
+    EXPECT_DOUBLE_EQ(portfolio->getInvestedValue(bars), 1050.0);
 }
 
 TEST_F(PortfolioTest, OpenShortPositionCorrectUnrealizedPnL) {
@@ -329,7 +329,7 @@ TEST_F(PortfolioTest, CloseLongPositionCorrectRealizedPnL) {
     Order closeOrder = createTestOrder(NQ_ID, SignalType::SELL, 110.0, -10);
     portfolio->executeOrder(closeOrder, true);
 
-    EXPECT_DOUBLE_EQ(portfolio->getRealizedPnL(), 97.30);
+    EXPECT_DOUBLE_EQ(portfolio->getRealizedPnL(), 94.6);
 }
 
 TEST_F(PortfolioTest, CloseLongPositionWithLoss) {
@@ -339,7 +339,7 @@ TEST_F(PortfolioTest, CloseLongPositionWithLoss) {
     Order closeOrder = createTestOrder(NQ_ID, SignalType::SELL, 95.0, -10);
     portfolio->executeOrder(closeOrder, true);
 
-    EXPECT_DOUBLE_EQ(portfolio->getRealizedPnL(), -52.70);
+    EXPECT_DOUBLE_EQ(portfolio->getRealizedPnL(), -55.40);
 }
 
 TEST_F(PortfolioTest, CloseLongPositionTotalEquityConservation) {
@@ -372,7 +372,7 @@ TEST_F(PortfolioTest, CloseShortPositionWithProfit) {
     Order closeOrder = createTestOrder(NQ_ID, SignalType::BUY, 90.0, 10);
     portfolio->executeOrder(closeOrder, true);
 
-    EXPECT_DOUBLE_EQ(portfolio->getRealizedPnL(), 97.30);
+    EXPECT_DOUBLE_EQ(portfolio->getRealizedPnL(), 94.60);
 }
 
 TEST_F(PortfolioTest, CloseShortPositionWithLoss) {
@@ -382,7 +382,7 @@ TEST_F(PortfolioTest, CloseShortPositionWithLoss) {
     Order closeOrder = createTestOrder(NQ_ID, SignalType::BUY, 105.0, 10);
     portfolio->executeOrder(closeOrder, true);
 
-    EXPECT_DOUBLE_EQ(portfolio->getRealizedPnL(), -52.70);
+    EXPECT_DOUBLE_EQ(portfolio->getRealizedPnL(), -55.40);
 }
 
 // ============================================================================
@@ -408,7 +408,7 @@ TEST_F(PortfolioTest, ReverseLongToShortCorrectPnL) {
     Order reverseOrder = createTestOrder(NQ_ID, SignalType::SELL, 110.0, -20);
     portfolio->executeOrder(reverseOrder, false);
 
-    EXPECT_DOUBLE_EQ(portfolio->getRealizedPnL(), 97.30);
+    EXPECT_DOUBLE_EQ(portfolio->getRealizedPnL(), 94.60);
 }
 
 TEST_F(PortfolioTest, ReverseLongToShortCorrectCash) {
@@ -443,7 +443,7 @@ TEST_F(PortfolioTest, ReverseShortToLongCorrectPnL) {
     Order reverseOrder = createTestOrder(NQ_ID, SignalType::BUY, 90.0, 20);
     portfolio->executeOrder(reverseOrder, false);
 
-    EXPECT_DOUBLE_EQ(portfolio->getRealizedPnL(), 97.30);
+    EXPECT_DOUBLE_EQ(portfolio->getRealizedPnL(), 94.60);
 }
 
 // ============================================================================

--- a/tests/test_portfolio.cpp
+++ b/tests/test_portfolio.cpp
@@ -7,7 +7,7 @@
 #include "backtest-cpp/portfolio.h"
 #include "backtest-cpp/types.h"
 
-const uint32_t NQ_ID = 0;
+const uint32_t NQ_ID = 1;
 
 // ============================================================================
 // Test Fixture - Reusable setup for tests
@@ -309,8 +309,7 @@ TEST_F(PortfolioTest, CloseLongPositionWithProfit) {
 
     Order closeOrder = createTestOrder(NQ_ID, SignalType::SELL, 110.0, -10);
     portfolio->executeOrder(closeOrder, true);
-
-    EXPECT_DOUBLE_EQ(portfolio->getAvailableCash(), 100097.3);
+    EXPECT_DOUBLE_EQ(portfolio->getAvailableCash(), 100094.6);
 }
 
 TEST_F(PortfolioTest, CloseLongPositionRemovesPosition) {


### PR DESCRIPTION
- rewrite executeOrder with OPEN, ADD, REDUCE, FLIP, CLOSE cases.
- add a trade to trades with 0 pnl and 0 quantity for OPEN and ADD orders. (To calculate the commision correctly in Pnl calculation) (there could be a better approach but idk)
- fix checkOverdraft
-  remove direction from Portfolio class
- change some false portfolio tests
- fix getInvestedValue, getRealizedPnl and some other functions in portfolio.