### PR TITLE
Add faster annualized Volatility function eliminating multiple passes.

### DIFF
--- a/performance/PERFORMANCE.md
+++ b/performance/PERFORMANCE.md
@@ -5,3 +5,4 @@
 |2026-07-03:23:33|./data/NQ_sample.csv|10.5596|2.88|0.43|3.06|12.34|New mmapped binary data gives enormous 18x performance gain in throughput. Memory footprint has also been almost halved. The other metrics are drastically worse from a % standpoint but in an absolute sense still very good imo.|
 |2026-07-13:16:56|./data/NQ_sample.csv|10.7216|0.18|0.45|3.52|12.51|First run with proper performance test pipeline that includes: core pinning, warmup runs, averaged results over N runs (here 20 runs)
 Throughput and max RSS are unchanged, while the previous spike in L1d miss % and Lower IPC were false signals|
+|2026-07-13:20:24|./data/NQ_sample.csv|11.0903|0.17|0.46|3.61|12.50|Minor performance gain from single pass volatility calculation. std::log has not been the bottleneck for volatility calculation|

--- a/src/performance.cpp
+++ b/src/performance.cpp
@@ -32,23 +32,21 @@ double Performance::annualizedReturn(const std::vector<EquityPoint>& curve, Freq
 double Performance::annualizedVolatility(const std::vector<EquityPoint>& curve, Frequency freq) {
     if (curve.size() < 3) throw std::runtime_error("Equity curve too short");
 
-    std::vector<double> returns;
-    returns.reserve(curve.size() - 1);
+    const size_t n = curve.size() - 1;
+    double sum = 0.0, sumSq = 0.0;
 
     for (size_t i = 1; i < curve.size(); ++i) {
-        returns.push_back(std::log(priceIntToDouble(curve[i].equity) / priceIntToDouble(curve[i - 1].equity)));
+        double r = std::log(priceIntToDouble(curve[i].equity) /
+                            priceIntToDouble(curve[i - 1].equity));
+        sum += r;
+        sumSq += r * r;
     }
 
-    double mean = 0.0;
-    for (double r : returns) mean += r;
-    mean /= static_cast<double>(returns.size());
+    double mean = sum / static_cast<double>(n);
+    double var = (sumSq - static_cast<double>(n) * mean * mean) /
+                 static_cast<double>(n - 1);
 
-    double var = 0.0;
-    for (double r : returns) var += (r - mean) * (r - mean);
-    var /= static_cast<double>(returns.size() - 1);
-
-    double annualPeriods = getAnnualization(freq).periodsPerYear;
-    return std::sqrt(var * annualPeriods);
+    return std::sqrt(var * getAnnualization(freq).periodsPerYear);
 }
 
 double Performance::sharpeRatio(const std::vector<EquityPoint>& curve, Frequency freq,


### PR DESCRIPTION
Experimented with custom numeric log functions, but they did not improve performance