### PR TITLE
Using reference to getNextBars() in hotloop instead of deep copy, +25% throughput

### DIFF
--- a/include/backtest-cpp/data.h
+++ b/include/backtest-cpp/data.h
@@ -24,7 +24,7 @@ class DataHandler {
     void loadAllCSVs(const std::string& directory, const std::string_view mode = "string");
     void loadAllCSVs(const std::string& directory, symbol_dictionary& symDict,
                      std::string_view mode);
-    const std::vector<Bar>& getNextBars();
+    std::vector<Bar>& getNextBars();
     const std::vector<Bar>& getCurrentBars() const;
     bool hasMoreData() const;
     void reset();

--- a/performance/PERFORMANCE.md
+++ b/performance/PERFORMANCE.md
@@ -7,3 +7,4 @@
 |2026-07-13:20:24|./data/NQ_sample.csv|11.0903|0.17|0.46|3.61|12.50|Minor performance gain from single pass volatility calculation. std::log has not been the bottleneck for volatility calculation|
 **Meps tracking updated to hotloop measurement only**. Previous values are in a context of the entire main function, not just the hot loop.|
 |2026-08-04:11:12|./data/NQ_sample.csv|25.1142|0.16|0.42|3.69|12.50|Updated tracking to hot loop. Pinned to performance core with set 4.8GHz frequency. Included designated isolcpu and testing on bare tty|
+|2026-08-25:17:42|./data/NQ_sample.csv|31.5850|0.18|0.72|3.45|12.51|Using references to make bar an alias for datahandler.getNextBars() in the hotloop, instead of a deep copy into a new vector on iteration|

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -186,7 +186,7 @@ const std::vector<Bar>& DataHandler::getCurrentBars() const {
     return currentMarketState_;
 }
 
-const std::vector<Bar>& DataHandler::getNextBars() {
+std::vector<Bar>& DataHandler::getNextBars() {
     int64_t max_time = std::numeric_limits<int64_t>::max();
     bool data_remains = false;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,7 +68,7 @@ int main() {
     // -------------------------------------------------
     auto start = std::chrono::steady_clock::now(); // Timing the hot loop
     while (dataHandler.hasMoreData()) {
-        std::vector<Bar> bars = dataHandler.getNextBars();
+        std::vector<Bar>& bars = dataHandler.getNextBars();
 
         // auto posIt = portfolio.getCurrentPositions().find(nq_id);
         // if (posIt != portfolio.getCurrentPositions().end() && bars[nq_id].time == 0) {


### PR DESCRIPTION
Using references to make bar an alias for datahandler.getNextBars() in the hotloop, instead of a deep copy into a new vector on iteration