### PR TITLE
Minor Hot-loop optimization from map to unordered_map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ Thumbs.db
 *.log
 
 TODO.txt
+/compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,3 +87,11 @@ if(PROJECT_IS_TOP_LEVEL)
     set(CPACK_GENERATOR "TGZ;ZIP")
     include(CPack)
 endif()
+
+if(PROJECT_IS_TOP_LEVEL AND CMAKE_EXPORT_COMPILE_COMMANDS)
+  file(CREATE_LINK
+    "${CMAKE_BINARY_DIR}/compile_commands.json"
+    "${CMAKE_SOURCE_DIR}/compile_commands.json"
+    SYMBOLIC
+  )
+endif()

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Run and profile the code via the analysis tool (currently linux only):
 ```bash
 sudo cpupower frequency-set -g performance
 sudo cpupower frequency-set -d 4.8GHz -u 4.8GHz  
+sudo cpupower frequency-set -d 400MHz -u 4.8GHz
+sudo cpupower -c 3 frequency-set -g performance
 taskset -c 3 ./build/release/performance/analyze
 ```  
 

--- a/include/backtest-cpp/portfolio.h
+++ b/include/backtest-cpp/portfolio.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <map>
 #include <optional>
+#include <unordered_map>
 #include <vector>
 
 #include "backtest-cpp/types.h"
@@ -16,8 +17,7 @@ struct PortfolioConfig {
 class Portfolio {
    public:
     Portfolio(const PortfolioConfig& config);
-
-    std::map<std::uint32_t, Position>& getCurrentPositions();
+    std::unordered_map<std::uint32_t, Position>& getCurrentPositions();
     int64_t getInvestedValue(const std::vector<Bar>& currentBars) const;
     int64_t getTotalEquity(const std::vector<Bar>& currentBar) const;
     int64_t getRealizedPnL() const;
@@ -34,7 +34,7 @@ class Portfolio {
     const double leverage_ = 1;
     const int64_t commission_ = priceDoubleToInt(2.70);
 
-    std::map<std::uint32_t, Position> positions_;  // Open Positions
+    std::unordered_map<std::uint32_t, Position> positions_;  // Open Positions
     std::vector<Order> orders_;                    // Open Orders
     std::vector<Trade> trades_;                    // Elapsed Trades
 };

--- a/include/backtest-cpp/strategy.h
+++ b/include/backtest-cpp/strategy.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <cstring>
 #include <deque>
-#include <map>
+#include <unordered_map>
 #include <optional>
 #include <vector>
 
@@ -14,15 +14,15 @@ class Strategy {
     virtual ~Strategy() = default;
     virtual void onInit(const std::vector<std::vector<Bar>>& availableData) = 0;
 
-    virtual std::map<uint32_t, std::optional<Signal>> onBars(
-        std::vector<Bar>& bars, std::map<uint32_t, Position>& positions) = 0;
+    virtual std::unordered_map<uint32_t, std::optional<Signal>> onBars(
+        std::vector<Bar>& bars, std::unordered_map<uint32_t, Position>& positions) = 0;
 
     virtual Order generateOrder(const Signal& signal, const Bar& currentBar,
                                 const double& maxInvest,
-                                std::map<uint32_t, Position>& positions) = 0;
+                                std::unordered_map<uint32_t, Position>& positions) = 0;
 
-    virtual std::map<uint32_t, Order> generateOrders(const std::map<uint32_t, Signal>& signals,
+    virtual std::unordered_map<uint32_t, Order> generateOrders(const std::unordered_map<uint32_t, Signal>& signals,
                                                      const std::vector<Bar>& currentBars,
                                                      const double& maxInvest,
-                                                     std::map<uint32_t, Position>& positions) = 0;
+                                                     std::unordered_map<uint32_t, Position>& positions) = 0;
 };

--- a/performance/PERFORMANCE.md
+++ b/performance/PERFORMANCE.md
@@ -9,3 +9,4 @@
 |2026-08-04:11:12|./data/NQ_sample.csv|25.1142|0.16|0.42|3.69|12.50|Updated tracking to hot loop. Pinned to performance core with set 4.8GHz frequency. Included designated isolcpu and testing on bare tty|
 |2026-08-25:17:42|./data/NQ_sample.csv|31.5850|0.18|0.72|3.45|12.51|Using references to make bar an alias for datahandler.getNextBars() in the hotloop, instead of a deep copy into a new vector on iteration|
 |2026-08-28:14:24|./data/NQ_sample.csv|39.0702|0.33|0.25|3.69|12.95|Run on isolated performance core DISABLING SMT Sibling setting Frequency to 4.8GHz|
+|2026-08-29:15:50|./data/NQ_sample.csv|41.0516|0.33|0.23|3.70|13.12|unordered_map instead of map in the hotloop|

--- a/performance/README.md
+++ b/performance/README.md
@@ -24,14 +24,14 @@ The backtest run over the same sample strategy and dataset is repeated N times (
 The execution is pinned to a performance core (Core 3 with 4.8GHz max) and the CPU governor is set to performance.
 Cores 3 and 4 are SMT siblings on the benchmark machine. I isolate cpu 3 and 4, then disable cpu 4 to use core 3 to make full use of the 4.8GHz performance core.
 
-## Quick run
+## Quick Benchmark
 ```bash
 sudo cpupower frequency-set -d 4.8GHz -u 4.8GHz  
 taskset -c 3 ./build/release/performance/analyze
 ```  
 
-## Isolated Core Run (Reboots system)
-### Set isolation
+## Full precise Benchmark
+### Set isolation (Reboots system)
 ```bash
 sudo kernelstub -a "isolcpus=domain,managed_irq,3,4 nohz_full=3,4 rcu_nocbs=3,4"
 sudo reboot

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_library(backtest_core)
 add_library(BacktestCpp::Core ALIAS backtest_core)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include(FetchContent)
 FetchContent_Declare(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <optional>
 #include <vector>
+#include <unordered_map>
 #if defined(__linux__)
 #include <sys/resource.h>  // for linux native performance tracking
 #endif
@@ -70,12 +71,6 @@ int main() {
     while (dataHandler.hasMoreData()) {
         std::vector<Bar>& bars = dataHandler.getNextBars();
 
-        // auto posIt = portfolio.getCurrentPositions().find(nq_id);
-        // if (posIt != portfolio.getCurrentPositions().end() && bars[nq_id].time == 0) {
-        //     std::cerr << "BUG: Have NQ position but bars doesn't contain NQ at bar " << barCount
-        //               << "\n";
-        // }
-
         // Execute open orders
         for (Order &order : openOrders) {
             for (const auto &bar : bars) {
@@ -88,7 +83,7 @@ int main() {
         }
         openOrders.clear();
 
-        std::map<uint32_t, std::optional<Signal>> signalMap =
+        std::unordered_map<uint32_t, std::optional<Signal>> signalMap =
             strategy.onBars(bars, portfolio.getCurrentPositions());
 
         for (const auto &[symbol, signal] : signalMap) {

--- a/src/portfolio.cpp
+++ b/src/portfolio.cpp
@@ -1,10 +1,10 @@
-#include "backtest-cpp/portfolio.h"
-
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
 #include <vector>
+#include <unordered_map>
 
+#include "backtest-cpp/portfolio.h"
 #include "backtest-cpp/types.h"
 
 Portfolio::Portfolio(const PortfolioConfig& config)
@@ -12,7 +12,7 @@ Portfolio::Portfolio(const PortfolioConfig& config)
       leverage_(config.leverage),
       commission_(priceDoubleToInt(config.commission)) {}
 
-std::map<std::uint32_t, Position>& Portfolio::getCurrentPositions() {
+std::unordered_map<std::uint32_t, Position>& Portfolio::getCurrentPositions() {
     return positions_;
 };
 

--- a/strategies/SMACrossover.cpp
+++ b/strategies/SMACrossover.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <iostream>
 #include <map>
+#include <unordered_map>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -46,13 +47,13 @@ void SMACrossover::onInit(const std::vector<std::vector<Bar>>& availableData) {
     initialized_ = true;
 }
 
-std::map<uint32_t, std::optional<Signal>> SMACrossover::onBars(std::vector<Bar>& bars,
-                                                               std::map<uint32_t, Position>&) {
+std::unordered_map<uint32_t, std::optional<Signal>> SMACrossover::onBars(std::vector<Bar>& bars,
+                                                               std::unordered_map<uint32_t, Position>&) {
     if (!initialized_) {
         return {};  // Not ready yet
     }
 
-    std::map<uint32_t, std::optional<Signal>> signalMap;
+    std::unordered_map<uint32_t, std::optional<Signal>> signalMap;
 
     for (const auto& bar : bars) {
         if (bar.symbol_id != this->symbol_id) continue;
@@ -94,7 +95,7 @@ std::map<uint32_t, std::optional<Signal>> SMACrossover::onBars(std::vector<Bar>&
 
 Order SMACrossover::generateOrder(const Signal& signal, const Bar& currentBar,
                                   const double& maxInvest,
-                                  std::map<uint32_t, Position>& positions) {
+                                  std::unordered_map<uint32_t, Position>& positions) {
     // Get current position (can be positive, negative, or zero)
     auto it = positions.find(currentBar.symbol_id);
     int current_position = (it != positions.end()) ? it->second.quantity : 0;
@@ -117,11 +118,11 @@ Order SMACrossover::generateOrder(const Signal& signal, const Bar& currentBar,
                  currentBar.close, OrderType::MARKET, quantity};
 }
 
-std::map<uint32_t, Order> SMACrossover::generateOrders(const std::map<uint32_t, Signal>& signals,
+std::unordered_map<uint32_t, Order> SMACrossover::generateOrders(const std::unordered_map<uint32_t, Signal>& signals,
                                                        const std::vector<Bar>& currentBars,
                                                        const double& maxInvest,
-                                                       std::map<uint32_t, Position>& positions) {
-    std::map<uint32_t, Order> orderMap;
+                                                       std::unordered_map<uint32_t, Position>& positions) {
+    std::unordered_map<uint32_t, Order> orderMap;
 
     for (const auto& [sig_symbol_id, signal] : signals) {
         // Get current position (can be positive, negative, or zero)

--- a/strategies/include/backtest-cpp/strategies/smacrossover.h
+++ b/strategies/include/backtest-cpp/strategies/smacrossover.h
@@ -8,15 +8,15 @@ class SMACrossover : public Strategy {
 
     void onInit(const std::vector<std::vector<Bar>>& availableData) override;
 
-    std::map<uint32_t, std::optional<Signal>> onBars(
-        std::vector<Bar>& bars, std::map<uint32_t, Position>& positions) override;
+    std::unordered_map<uint32_t, std::optional<Signal>> onBars(
+        std::vector<Bar>& bars, std::unordered_map<uint32_t, Position>& positions) override;
     Order generateOrder(const Signal& signal, const Bar& currentBar, const double& maxInvest,
-                        std::map<uint32_t, Position>& positions) override;
+                        std::unordered_map<uint32_t, Position>& positions) override;
 
-    std::map<uint32_t, Order> generateOrders(const std::map<uint32_t, Signal>& signals,
+    std::unordered_map<uint32_t, Order> generateOrders(const std::unordered_map<uint32_t, Signal>& signals,
                                              const std::vector<Bar>& currentBars,
                                              const double& maxInvest,
-                                             std::map<uint32_t, Position>& positions) override;
+                                             std::unordered_map<uint32_t, Position>& positions) override;
 
    private:
     uint32_t symbol_id;


### PR DESCRIPTION
Replaced map with unordered_map in the hotloop (esp. in the strategy and portfolio functionality). 
This is a temporary fix since we should implement a vector for the positions/signals anyway and I am actively re-writing the virtual strategy via CRTP.